### PR TITLE
Add design page imagery and treated portraits

### DIFF
--- a/src/components/widgets/Testimonials.astro
+++ b/src/components/widgets/Testimonials.astro
@@ -25,44 +25,49 @@ const {
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     {
       testimonials &&
-        testimonials.map(({ title, testimonial, name, job, image }) => (
-          <div class="flex h-auto">
-            <div class="flex flex-col rounded-md p-4 shadow-xl dark:border dark:border-border dark:shadow-none md:p-6">
-              {title && <h2 class="pb-4 text-lg font-medium leading-6">{title}</h2>}
-              {testimonial && (
-                <blockquote class="flex-auto">
-                  <p class="text-muted">" {testimonial} "</p>
-                </blockquote>
-              )}
+        testimonials.map(({ title, testimonial, name, job, image }) => {
+          const attribution = name || job || 'Client';
+          const role = name && job ? job : undefined;
 
-              <hr class="my-4 border-accent" />
-
-              <div class="flex items-center">
-                {image && (
-                  <div class="h-10 w-10 rounded-full border border-border dark:border-border">
-                    {typeof image === 'string' ? (
-                      <Fragment set:html={image} />
-                    ) : (
-                      <Image
-                        class="h-10 min-h-full w-10 min-w-full rounded-full border border-border dark:border-border"
-                        width={40}
-                        height={40}
-                        widths={[400, 768]}
-                        layout="fixed"
-                        {...(typeof image === 'object' && image !== null ? image : {})}
-                      />
-                    )}
-                  </div>
+          return (
+            <div class="flex h-auto">
+              <div class="flex flex-col rounded-md p-4 shadow-xl dark:border dark:border-border dark:shadow-none md:p-6">
+                {title && <h2 class="pb-4 text-lg font-medium leading-6">{title}</h2>}
+                {testimonial && (
+                  <blockquote class="flex-auto">
+                    <p class="text-muted">" {testimonial} "</p>
+                  </blockquote>
                 )}
 
-                <div class="ml-3 grow rtl:ml-0 rtl:mr-3">
-                  {name && <p class="text-base font-semibold">{name}</p>}
-                  {job && <p class="text-xs text-muted">{job}</p>}
+                <hr class="my-4 border-accent" />
+
+                <div class="flex items-center">
+                  {image && (
+                    <div class="h-10 w-10 rounded-full border border-border dark:border-border">
+                      {typeof image === 'string' ? (
+                        <Fragment set:html={image} />
+                      ) : (
+                        <Image
+                          class="h-10 min-h-full w-10 min-w-full rounded-full border border-border dark:border-border"
+                          width={40}
+                          height={40}
+                          widths={[400, 768]}
+                          layout="fixed"
+                          {...(typeof image === 'object' && image !== null ? image : {})}
+                        />
+                      )}
+                    </div>
+                  )}
+
+                  <div class="ml-3 grow rtl:ml-0 rtl:mr-3">
+                    <p class="text-base font-semibold">{attribution}</p>
+                    {role && <p class="text-xs text-muted">{role}</p>}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ))
+          );
+        })
     }
   </div>
   {

--- a/src/pages/services/design.astro
+++ b/src/pages/services/design.astro
@@ -137,7 +137,7 @@ const consultingFAQs = [
       alt: 'Illustration of duplicated tools, broken handoffs, and scattered software interfaces resolving into a clearer workflow',
       width: 1400,
       height: 1100,
-      loading: 'eager',
+      loading: 'lazy',
     }}
   />
 
@@ -151,7 +151,7 @@ const consultingFAQs = [
       alt: 'Styled portrait of Keith with subtle workflow and dashboard accents',
       width: 1200,
       height: 1400,
-      loading: 'eager',
+      loading: 'lazy',
     }}
     isReversed={true}
   />
@@ -220,7 +220,7 @@ const consultingFAQs = [
       alt: 'Vertical roadmap illustration for discovery, planning, setup, and ongoing support',
       width: 1024,
       height: 1536,
-      loading: 'eager',
+      loading: 'lazy',
     }}
     items={[
       {
@@ -243,25 +243,19 @@ const consultingFAQs = [
   />
 
   {/* 10. Testimonials */}
-  {
-    /* TODO: Testimonial names look like AI-generated placeholders ("Alex Rivera", "Morgan Lee", "Jamie Chen"). Replace with real client testimonials or anonymize (e.g., "Independent Creator", "Small Business Owner"). */
-  }
   <Testimonials
     title="What Clients Say"
     testimonials={[
       {
-        name: 'Alex Rivera',
-        job: 'Artist & Entrepreneur',
+        job: 'Independent Creator',
         testimonial:
           'Resonant Design transformed my creative workflow. I save hours every week and feel more in control of my business.',
       },
       {
-        name: 'Morgan Lee',
         job: 'Small Business Owner',
         testimonial: 'The personalized tech advice was a game changer. Highly recommend for any solopreneur.',
       },
       {
-        name: 'Jamie Chen',
         job: 'Content Creator',
         testimonial: 'I finally have a system that works for me, not against me. The ongoing support is invaluable.',
       },


### PR DESCRIPTION
Summary
- add `scripts/generate-design-images.mjs` to produce the four requested design assets using Sharp-based SVG overlays
- swap in the new hero/workflow illustration, pain-point asset, Keith portrait, and roadmap graphic inside `src/pages/services/design.astro`, supplying explicit metadata and lazy loading
- refresh the testimonials data to remove placeholder names and ensure fallbacks, and keep the rest of the layout unchanged

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced testimonials display with improved author attribution and role information.

* **Performance**
  * Implemented lazy loading for hero images on the design services page.

* **Content Updates**
  * Updated testimonials data on design services page, including removed client identifiers and revised job title to "Independent Creator."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->