### PR TITLE
Add editorial writing section with Frequency Music integration

### DIFF
--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -6,11 +6,12 @@ Detailed architecture reference for Claude Code when working on this codebase.
 
 Three collections defined in `src/content/config.ts`:
 
-| Collection    | Source              | Loader                                                         |
-| ------------- | ------------------- | -------------------------------------------------------------- |
-| **post**      | `src/content/post/` | Local MDX via glob loader                                      |
-| **til**       | `src/content/til/`  | "Today I Learned" markdown                                     |
-| **resources** | Notion database     | Vendored `notion-astro-loader` (filters Status = "Up-to-Date") |
+| Collection     | Source                            | Loader                                                                     |
+| -------------- | --------------------------------- | -------------------------------------------------------------------------- |
+| **post**       | `src/content/post/`               | Local MDX via glob loader                                                  |
+| **til**        | `src/content/til/`                | "Today I Learned" markdown                                                 |
+| **editorial**  | Frequency Music export snapshot   | Custom `githubEditorialLoader` (local FS in dev, remote URL in production) |
+| **resources**  | Notion database                   | Vendored `notion-astro-loader` (filters Status = "Up-to-Date")             |
 
 The vendored loader in `vendor/notion-astro-loader/` is a local fork. Modify there for Notion integration changes.
 

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -6,12 +6,12 @@ Detailed architecture reference for Claude Code when working on this codebase.
 
 Four collections defined in `src/content/config.ts`:
 
-| Collection     | Source                            | Loader                                                                     |
-| -------------- | --------------------------------- | -------------------------------------------------------------------------- |
-| **post**       | `src/content/post/`               | Local MDX via glob loader                                                  |
-| **til**        | `src/content/til/`                | "Today I Learned" markdown                                                 |
-| **editorial**  | Frequency Music export snapshot   | Custom `githubEditorialLoader` (local FS in dev, remote URL in production) |
-| **resources**  | Notion database                   | Vendored `notion-astro-loader` (filters Status = "Up-to-Date")             |
+| Collection    | Source                          | Loader                                                                     |
+| ------------- | ------------------------------- | -------------------------------------------------------------------------- |
+| **post**      | `src/content/post/`             | Local MDX via glob loader                                                  |
+| **til**       | `src/content/til/`              | Local markdown via glob loader ("Today I Learned")                         |
+| **editorial** | Frequency Music export snapshot | Custom `githubEditorialLoader` (local FS in dev, remote URL in production) |
+| **resources** | Notion database                 | Vendored `notion-astro-loader` (filters Status = "Up-to-Date")             |
 
 The vendored loader in `vendor/notion-astro-loader/` is a local fork. Modify there for Notion integration changes.
 

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -4,7 +4,7 @@ Detailed architecture reference for Claude Code when working on this codebase.
 
 ## Content Collections
 
-Three collections defined in `src/content/config.ts`:
+Four collections defined in `src/content/config.ts`:
 
 | Collection     | Source                            | Loader                                                                     |
 | -------------- | --------------------------------- | -------------------------------------------------------------------------- |

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,6 +2,7 @@ import { defineCollection, z } from 'astro:content';
 import { file, glob, type Loader } from 'astro/loaders';
 import { existsSync } from 'node:fs';
 import type { NotionLoaderOptions } from '../vendor/notion-astro-loader/src/loader.js';
+import { githubEditorialLoader } from './loaders/githubEditorialLoader';
 
 const parseResourcesCache = (source: string): Array<Record<string, unknown>> => {
   let payload: unknown;
@@ -151,6 +152,23 @@ const tilCollection = defineCollection({
     }),
 });
 
+const editorialCollection = defineCollection({
+  loader: githubEditorialLoader(),
+  schema: z.object({
+    title: z.string(),
+    slug: z.string(),
+    kind: z.enum(['experiment_recap', 'what_changed_my_mind', 'campaign_summary', 'thesis_summary']),
+    publishedAt: z.coerce.date(),
+    dek: z.string(),
+    evidenceStatus: z.enum(['supported', 'mixed', 'speculative']),
+    uncertaintySummary: z.string(),
+    whyItMatters: z.string(),
+    campaignSlug: z.string().optional(),
+    thesisSlugs: z.array(z.string()).optional(),
+    canonicalAppUrl: z.string().url(),
+  }),
+});
+
 const notionToken = import.meta.env.NOTION_TOKEN;
 const notionResourcesDatabaseId = import.meta.env.NOTION_RR_RESOURCES_ID;
 
@@ -162,6 +180,7 @@ const resourcesLoader =
 export const collections = {
   post: postCollection,
   til: tilCollection,
+  editorial: editorialCollection,
   resources: defineCollection({
     loader: resourcesLoader,
     // Schema: start from Notion property types; refine as needed
@@ -199,4 +218,3 @@ export const collections = {
       }),
   }),
 };
-

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -49,7 +49,7 @@ function parseMarkdownDocument(source: string): {
   frontmatter: Record<string, unknown>;
   body: string;
 } {
-  const match = source.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!match) {
     throw new Error('Editorial markdown file is missing frontmatter.');
   }
@@ -62,7 +62,16 @@ function parseMarkdownDocument(source: string): {
 }
 
 async function fetchText(url: URL): Promise<string> {
-  const response = await fetch(url);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url.toString()}: ${response.status} ${response.statusText}`);
   }

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -1,0 +1,157 @@
+import type { Loader } from 'astro/loaders';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
+
+type EditorialManifestEntry = {
+  slug: string;
+  path: string;
+  title: string;
+  kind: 'experiment_recap' | 'what_changed_my_mind' | 'campaign_summary' | 'thesis_summary';
+  publishedAt: number;
+  evidenceStatus: 'supported' | 'mixed' | 'speculative';
+};
+
+type EditorialManifest = {
+  version: 'public_editorial_v1';
+  generatedAt?: string;
+  items: EditorialManifestEntry[];
+};
+
+type ManifestSource =
+  | {
+      mode: 'remote';
+      manifestUrl: URL;
+      contentBaseUrl: URL;
+      manifest: EditorialManifest;
+    }
+  | {
+      mode: 'local';
+      baseDir: string;
+      manifest: EditorialManifest;
+    };
+
+const DEFAULT_LOCAL_EXPORT_DIR = resolve(
+  process.cwd(),
+  '../frequency-music/exports/public-editorial/v1',
+);
+
+function parseManifest(raw: string): EditorialManifest {
+  const parsed = JSON.parse(raw) as Partial<EditorialManifest>;
+  if (parsed.version !== 'public_editorial_v1' || !Array.isArray(parsed.items)) {
+    throw new Error('Editorial manifest is missing the public_editorial_v1 contract.');
+  }
+  return parsed as EditorialManifest;
+}
+
+function parseMarkdownDocument(source: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const match = source.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    throw new Error('Editorial markdown file is missing frontmatter.');
+  }
+
+  const frontmatter = loadYaml(match[1] ?? '') as Record<string, unknown>;
+  return {
+    frontmatter,
+    body: match[2] ?? '',
+  };
+}
+
+async function fetchText(url: URL): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url.toString()}: ${response.status} ${response.statusText}`);
+  }
+  return await response.text();
+}
+
+async function loadManifestSource(): Promise<ManifestSource | null> {
+  const manifestUrl = process.env.EDITORIAL_MANIFEST_URL;
+  if (manifestUrl) {
+    const manifestLocation = new URL(manifestUrl);
+    const contentBaseUrl = process.env.EDITORIAL_CONTENT_BASE_URL
+      ? new URL(process.env.EDITORIAL_CONTENT_BASE_URL)
+      : new URL('./', manifestLocation);
+    const manifest = parseManifest(await fetchText(manifestLocation));
+    return {
+      mode: 'remote',
+      manifestUrl: manifestLocation,
+      contentBaseUrl,
+      manifest,
+    };
+  }
+
+  const localBaseDir =
+    process.env.EDITORIAL_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
+  const manifestPath = join(localBaseDir, 'manifest.json');
+
+  let manifestRaw: string;
+  try {
+    manifestRaw = await readFile(manifestPath, 'utf8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+
+  const manifest = parseManifest(manifestRaw);
+  return {
+    mode: 'local',
+    baseDir: localBaseDir,
+    manifest,
+  };
+}
+
+async function loadMarkdownEntry(
+  source: ManifestSource,
+  relativePath: string,
+): Promise<{ raw: string; fileUrl?: URL }> {
+  if (source.mode === 'remote') {
+    const url = new URL(relativePath, source.contentBaseUrl);
+    return { raw: await fetchText(url), fileUrl: url };
+  }
+
+  const filePath = join(source.baseDir, relativePath);
+  return {
+    raw: await readFile(filePath, 'utf8'),
+    fileUrl: pathToFileURL(filePath),
+  };
+}
+
+export function githubEditorialLoader(): Loader {
+  return {
+    name: 'github-editorial-loader',
+    load: async (context) => {
+      const source = await loadManifestSource();
+
+      if (!source) {
+        context.logger.warn(
+          'No editorial manifest configured. Set EDITORIAL_MANIFEST_URL or provide a local export snapshot.',
+        );
+        return;
+      }
+
+      context.store.clear();
+
+      for (const item of source.manifest.items) {
+        const { raw, fileUrl } = await loadMarkdownEntry(source, item.path);
+        const { frontmatter, body } = parseMarkdownDocument(raw);
+        const parsedData = await context.parseData({
+          id: item.slug,
+          data: frontmatter,
+        });
+        const rendered = await context.renderMarkdown(body, { fileURL: fileUrl });
+        context.store.set({
+          id: item.slug,
+          data: parsedData,
+          body,
+          digest: context.generateDigest(raw),
+          rendered,
+        });
+      }
+    },
+  };
+}

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -32,10 +32,7 @@ type ManifestSource =
       manifest: EditorialManifest;
     };
 
-const DEFAULT_LOCAL_EXPORT_DIR = resolve(
-  process.cwd(),
-  '../frequency-music/exports/public-editorial/v1',
-);
+const DEFAULT_LOCAL_EXPORT_DIR = resolve(process.cwd(), '../frequency-music/exports/public-editorial/v1');
 
 function parseManifest(raw: string): EditorialManifest {
   const parsed = JSON.parse(raw) as Partial<EditorialManifest>;
@@ -94,8 +91,7 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
     };
   }
 
-  const localBaseDir =
-    process.env.EDITORIAL_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
+  const localBaseDir = process.env.EDITORIAL_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
   const manifestPath = join(localBaseDir, 'manifest.json');
 
   let manifestRaw: string;
@@ -116,7 +112,7 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
 
 async function loadMarkdownEntry(
   source: ManifestSource,
-  relativePath: string,
+  relativePath: string
 ): Promise<{ raw: string; fileUrl?: URL }> {
   if (source.mode === 'remote') {
     const url = new URL(relativePath, source.contentBaseUrl);
@@ -133,12 +129,13 @@ async function loadMarkdownEntry(
 export function githubEditorialLoader(): Loader {
   return {
     name: 'github-editorial-loader',
-    load: async (context) => {
+    load: async context => {
       const source = await loadManifestSource();
 
       if (!source) {
+        context.store.clear();
         context.logger.warn(
-          'No editorial manifest configured. Set EDITORIAL_MANIFEST_URL or provide a local export snapshot.',
+          'No editorial manifest configured. Set EDITORIAL_MANIFEST_URL or provide a local export snapshot.'
         );
         return;
       }
@@ -146,20 +143,26 @@ export function githubEditorialLoader(): Loader {
       context.store.clear();
 
       for (const item of source.manifest.items) {
-        const { raw, fileUrl } = await loadMarkdownEntry(source, item.path);
-        const { frontmatter, body } = parseMarkdownDocument(raw);
-        const parsedData = await context.parseData({
-          id: item.slug,
-          data: frontmatter,
-        });
-        const rendered = await context.renderMarkdown(body, { fileURL: fileUrl });
-        context.store.set({
-          id: item.slug,
-          data: parsedData,
-          body,
-          digest: context.generateDigest(raw),
-          rendered,
-        });
+        try {
+          const { raw, fileUrl } = await loadMarkdownEntry(source, item.path);
+          const { frontmatter, body } = parseMarkdownDocument(raw);
+          const parsedData = await context.parseData({
+            id: item.slug,
+            data: frontmatter,
+          });
+          const rendered = await context.renderMarkdown(body, { fileURL: fileUrl });
+          context.store.set({
+            id: item.slug,
+            data: parsedData,
+            body,
+            digest: context.generateDigest(raw),
+            rendered,
+          });
+        } catch (err) {
+          context.logger.error(
+            `Failed to load editorial entry "${item.slug}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
     },
   };

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -80,6 +80,10 @@ export const headerData = {
       ],
     },
     {
+      text: 'Writing',
+      href: getPermalink('/writing'),
+    },
+    {
       text: 'Resources',
       href: getPermalink('/resources/all/1'),
     },
@@ -112,6 +116,7 @@ export const footerData = {
       title: 'Content',
       links: [
         { text: 'Blog', href: getBlogPermalink() },
+        { text: 'Writing', href: getPermalink('/writing') },
         { text: 'Resources', href: getPermalink('/resources/all/1') },
         { text: 'TIL', href: getPermalink('/til/all/1') },
         { text: 'Categories', href: getBlogCategoryPermalink() },

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -15,17 +15,15 @@ export const GET = async () => {
   const posts = await fetchPosts();
 
   const rss = await getRssString({
-    title: `${SITE.name}’s Blog`,
+    title: `${SITE.name}'s Blog`,
     description: METADATA?.description || '',
     site: import.meta.env.SITE,
-
     items: posts.map(post => ({
       link: getPermalink(post.permalink, 'post'),
       title: post.title,
       description: post.excerpt,
       pubDate: post.publishDate,
     })),
-
     trailingSlash: SITE.trailingSlash,
   });
 

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -26,7 +26,7 @@ const metadata = {
 <Layout metadata={metadata}>
   <section class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
     <div class="mb-8">
-      <a href="/writing" class="text-primary transition-colors hover:text-accent">
+      <a href="/writing" class="text-primary transition-colors hover:text-accent focus-visible:underline focus-visible:outline-none">
         ← Back to writing
       </a>
     </div>
@@ -63,8 +63,9 @@ const metadata = {
       <div class="mt-10 border-t border-border pt-6">
         <a
           href={entry.data.canonicalAppUrl}
-          class="text-primary transition-colors hover:text-accent"
-          rel="noreferrer"
+          class="text-primary transition-colors hover:text-accent focus-visible:underline focus-visible:outline-none"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Open source artifact in Frequency Music
         </a>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -26,12 +26,15 @@ const metadata = {
 <Layout metadata={metadata}>
   <section class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
     <div class="mb-8">
-      <a href="/writing" class="text-primary transition-colors hover:text-accent focus-visible:underline focus-visible:outline-none">
+      <a
+        href="/writing"
+        class="text-primary transition-colors hover:text-accent focus-visible:underline focus-visible:outline-none"
+      >
         ← Back to writing
       </a>
     </div>
 
-    <article data-pagefind-body class="rounded-3xl border border-border bg-card/70 px-6 py-8 shadow-sm sm:px-10">
+    <article data-pagefind-body class="bg-card/70 rounded-3xl border border-border px-6 py-8 shadow-sm sm:px-10">
       <div class="mb-5 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary">
         <span>{entry.data.kind.replaceAll('_', ' ')}</span>
         <span class="text-muted-foreground">•</span>
@@ -45,7 +48,7 @@ const metadata = {
       <h1 class="mb-4 text-4xl font-bold tracking-tighter md:text-5xl">{entry.data.title}</h1>
       <p class="text-muted-foreground mb-8 text-lg leading-8">{entry.data.dek}</p>
 
-      <div class="mb-8 grid gap-4 rounded-2xl border border-border bg-background/80 p-5 md:grid-cols-2">
+      <div class="bg-background/80 mb-8 grid gap-4 rounded-2xl border border-border p-5 md:grid-cols-2">
         <div>
           <p class="mb-2 text-xs uppercase tracking-[0.18em] text-primary">Why It Matters</p>
           <p class="text-muted-foreground leading-7">{entry.data.whyItMatters}</p>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -1,0 +1,74 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '~/layouts/PageLayout.astro';
+import { getFormattedDate } from '~/utils/utils';
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const entries = await getCollection('editorial');
+  return entries.map(entry => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const renderedHtml = entry.rendered?.html;
+
+const metadata = {
+  title: entry.data.title,
+  description: entry.data.dek,
+  canonical: entry.data.canonicalAppUrl,
+};
+---
+
+<Layout metadata={metadata}>
+  <section class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+    <div class="mb-8">
+      <a href="/writing" class="text-primary transition-colors hover:text-accent">
+        ← Back to writing
+      </a>
+    </div>
+
+    <article data-pagefind-body class="rounded-3xl border border-border bg-card/70 px-6 py-8 shadow-sm sm:px-10">
+      <div class="mb-5 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary">
+        <span>{entry.data.kind.replaceAll('_', ' ')}</span>
+        <span class="text-muted-foreground">•</span>
+        <span>{entry.data.evidenceStatus}</span>
+        <span class="text-muted-foreground">•</span>
+        <time datetime={entry.data.publishedAt.toISOString()}>
+          {getFormattedDate(entry.data.publishedAt)}
+        </time>
+      </div>
+
+      <h1 class="mb-4 text-4xl font-bold tracking-tighter md:text-5xl">{entry.data.title}</h1>
+      <p class="text-muted-foreground mb-8 text-lg leading-8">{entry.data.dek}</p>
+
+      <div class="mb-8 grid gap-4 rounded-2xl border border-border bg-background/80 p-5 md:grid-cols-2">
+        <div>
+          <p class="mb-2 text-xs uppercase tracking-[0.18em] text-primary">Why It Matters</p>
+          <p class="text-muted-foreground leading-7">{entry.data.whyItMatters}</p>
+        </div>
+        <div>
+          <p class="mb-2 text-xs uppercase tracking-[0.18em] text-primary">Uncertainty</p>
+          <p class="text-muted-foreground leading-7">{entry.data.uncertaintySummary}</p>
+        </div>
+      </div>
+
+      <div class="prose prose-lg max-w-none dark:prose-invert">
+        {renderedHtml ? <Fragment set:html={renderedHtml} /> : <p>No content available.</p>}
+      </div>
+
+      <div class="mt-10 border-t border-border pt-6">
+        <a
+          href={entry.data.canonicalAppUrl}
+          class="text-primary transition-colors hover:text-accent"
+          rel="noreferrer"
+        >
+          Open source artifact in Frequency Music
+        </a>
+      </div>
+    </article>
+  </section>
+</Layout>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -38,7 +38,7 @@ const metadata = {
           {entries.map(entry => (
             <a
               href={`/writing/${entry.id}`}
-              class="group rounded-2xl border border-border bg-card px-6 py-5 transition-colors hover:border-primary/40"
+              class="group rounded-2xl border border-border bg-card px-6 py-5 transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               <div class="mb-3 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary">
                 <span>{entry.data.kind.replaceAll('_', ' ')}</span>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -6,7 +6,7 @@ import { getFormattedDate } from '~/utils/utils';
 export const prerender = true;
 
 const entries = (await getCollection('editorial')).sort(
-  (left, right) => right.data.publishedAt.getTime() - left.data.publishedAt.getTime(),
+  (left, right) => right.data.publishedAt.getTime() - left.data.publishedAt.getTime()
 );
 
 const metadata = {
@@ -19,18 +19,16 @@ const metadata = {
   <section class="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
     <div class="mb-10 max-w-3xl">
       <p class="mb-3 text-sm uppercase tracking-[0.24em] text-primary">Writing</p>
-      <h1 class="mb-4 text-4xl font-bold tracking-tighter md:text-5xl">
-        Public notes from the research-to-music loop
-      </h1>
+      <h1 class="mb-4 text-4xl font-bold tracking-tighter md:text-5xl">Public notes from the research-to-music loop</h1>
       <p class="text-muted-foreground text-lg leading-8">
-        These entries are exported snapshots, not live database joins. Each piece is meant to say what was tried,
-        what changed, and what still remains uncertain.
+        These entries are exported snapshots, not live database joins. Each piece is meant to say what was tried, what
+        changed, and what still remains uncertain.
       </p>
     </div>
 
     {
       entries.length === 0 ? (
-        <div class="rounded-2xl border border-border bg-card px-6 py-10 text-muted-foreground">
+        <div class="text-muted-foreground rounded-2xl border border-border bg-card px-6 py-10">
           No editorial snapshots are published yet.
         </div>
       ) : (
@@ -38,20 +36,16 @@ const metadata = {
           {entries.map(entry => (
             <a
               href={`/writing/${entry.id}`}
-              class="group rounded-2xl border border-border bg-card px-6 py-5 transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              class="hover:border-primary/40 group rounded-2xl border border-border bg-card px-6 py-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               <div class="mb-3 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary">
                 <span>{entry.data.kind.replaceAll('_', ' ')}</span>
                 <span class="text-muted-foreground">•</span>
                 <span>{entry.data.evidenceStatus}</span>
                 <span class="text-muted-foreground">•</span>
-                <time datetime={entry.data.publishedAt.toISOString()}>
-                  {getFormattedDate(entry.data.publishedAt)}
-                </time>
+                <time datetime={entry.data.publishedAt.toISOString()}>{getFormattedDate(entry.data.publishedAt)}</time>
               </div>
-              <h2 class="mb-2 text-2xl font-semibold tracking-tight group-hover:text-primary">
-                {entry.data.title}
-              </h2>
+              <h2 class="mb-2 text-2xl font-semibold tracking-tight group-hover:text-primary">{entry.data.title}</h2>
               <p class="text-muted-foreground leading-7">{entry.data.dek}</p>
             </a>
           ))}

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -1,0 +1,62 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '~/layouts/PageLayout.astro';
+import { getFormattedDate } from '~/utils/utils';
+
+export const prerender = true;
+
+const entries = (await getCollection('editorial')).sort(
+  (left, right) => right.data.publishedAt.getTime() - left.data.publishedAt.getTime(),
+);
+
+const metadata = {
+  title: 'Writing',
+  description: 'Public narrative snapshots exported from the Frequency Music research workflow.',
+};
+---
+
+<Layout metadata={metadata}>
+  <section class="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+    <div class="mb-10 max-w-3xl">
+      <p class="mb-3 text-sm uppercase tracking-[0.24em] text-primary">Writing</p>
+      <h1 class="mb-4 text-4xl font-bold tracking-tighter md:text-5xl">
+        Public notes from the research-to-music loop
+      </h1>
+      <p class="text-muted-foreground text-lg leading-8">
+        These entries are exported snapshots, not live database joins. Each piece is meant to say what was tried,
+        what changed, and what still remains uncertain.
+      </p>
+    </div>
+
+    {
+      entries.length === 0 ? (
+        <div class="rounded-2xl border border-border bg-card px-6 py-10 text-muted-foreground">
+          No editorial snapshots are published yet.
+        </div>
+      ) : (
+        <div class="grid gap-4">
+          {entries.map(entry => (
+            <a
+              href={`/writing/${entry.id}`}
+              class="group rounded-2xl border border-border bg-card px-6 py-5 transition-colors hover:border-primary/40"
+            >
+              <div class="mb-3 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary">
+                <span>{entry.data.kind.replaceAll('_', ' ')}</span>
+                <span class="text-muted-foreground">•</span>
+                <span>{entry.data.evidenceStatus}</span>
+                <span class="text-muted-foreground">•</span>
+                <time datetime={entry.data.publishedAt.toISOString()}>
+                  {getFormattedDate(entry.data.publishedAt)}
+                </time>
+              </div>
+              <h2 class="mb-2 text-2xl font-semibold tracking-tight group-hover:text-primary">
+                {entry.data.title}
+              </h2>
+              <p class="text-muted-foreground leading-7">{entry.data.dek}</p>
+            </a>
+          ))}
+        </div>
+      )
+    }
+  </section>
+</Layout>

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -104,8 +104,8 @@ const normalizeEditorialEntry = (entry: CollectionEntry<'editorial'>): Post => {
   const kind = entry.data.kind.replaceAll('_', ' ');
   return {
     id: entry.id,
-    slug: entry.data.slug,
-    permalink: `writing/${entry.data.slug}`,
+    slug: entry.id,
+    permalink: `writing/${entry.id}`,
     publishDate: entry.data.publishedAt,
     title: entry.data.title,
     excerpt: entry.data.dek,
@@ -231,12 +231,14 @@ export const getStaticPathsBlogList = async ({ paginate }: { paginate: PaginateF
 /** */
 export const getStaticPathsBlogPost = async () => {
   if (!isBlogEnabled || !isBlogPostRouteEnabled) return [];
-  return (await fetchPosts()).flatMap(post => ({
-    params: {
-      blog: post.permalink,
-    },
-    props: { post },
-  }));
+  return (await fetchPosts())
+    .filter(post => !post.permalink.startsWith('writing/'))
+    .flatMap(post => ({
+      params: {
+        blog: post.permalink,
+      },
+      props: { post },
+    }));
 };
 
 /** */

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -100,11 +100,29 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
   };
 };
 
+const normalizeEditorialEntry = (entry: CollectionEntry<'editorial'>): Post => {
+  const kind = entry.data.kind.replaceAll('_', ' ');
+  return {
+    id: entry.id,
+    slug: entry.data.slug,
+    permalink: `writing/${entry.data.slug}`,
+    publishDate: entry.data.publishedAt,
+    title: entry.data.title,
+    excerpt: entry.data.dek,
+    category: { slug: 'writing', title: 'Writing' },
+    tags: [{ slug: entry.data.kind.replaceAll('_', '-'), title: kind.replace(/\b\w/g, c => c.toUpperCase()) }],
+    draft: false,
+    metadata: {},
+  };
+};
+
 const load = async function (): Promise<Array<Post>> {
   const posts = await getCollection('post');
+  const editorialEntries = await getCollection('editorial');
   const normalizedPosts = posts.map(async post => await getNormalizedPost(post));
+  const normalizedEditorial = editorialEntries.map(normalizeEditorialEntry);
 
-  const results = (await Promise.all(normalizedPosts))
+  const results = [...(await Promise.all(normalizedPosts)), ...normalizedEditorial]
     .sort((a, b) => b.publishDate.valueOf() - a.publishDate.valueOf())
     .filter(post => !post.draft);
 

--- a/src/utils/internal-linking.ts
+++ b/src/utils/internal-linking.ts
@@ -4,7 +4,7 @@
  */
 
 export interface PageRelationship {
-  type: 'service' | 'blog' | 'til' | 'about' | 'landing';
+  type: 'service' | 'blog' | 'editorial' | 'til' | 'about' | 'landing';
   title: string;
   href: string;
   description: string;
@@ -108,6 +108,15 @@ export const SITE_STRUCTURE: Record<string, PageRelationship> = {
     icon: 'tabler:article',
     priority: 7,
     tags: ['blog', 'articles', 'insights', 'technology'],
+  },
+  '/writing': {
+    type: 'editorial',
+    title: 'Writing',
+    href: '/writing',
+    description: 'Public narrative snapshots from the Frequency Music research workflow',
+    icon: 'tabler:pencil',
+    priority: 7,
+    tags: ['writing', 'editorial', 'research', 'music', 'essays'],
   },
   '/til': {
     type: 'til',
@@ -219,6 +228,11 @@ export function generateLinkSuggestions(content: string, currentPath: string): L
     blog: '/blog',
     articles: '/blog',
     insights: '/blog',
+
+    writing: '/writing',
+    editorial: '/writing',
+    research: '/writing',
+    essays: '/writing',
 
     learn: '/til',
     'today i learned': '/til',
@@ -354,6 +368,12 @@ export function getBreadcrumbPath(pathname: string): Array<{ text: string; href?
         breadcrumbs.push({ text: 'Post' });
       }
     }
+  } else if (pathname.startsWith('/writing')) {
+    breadcrumbs.push({ text: 'Writing', href: '/writing', icon: 'tabler:pencil' });
+
+    if (segments.length > 1) {
+      breadcrumbs.push({ text: formatSegmentText(segments[1]) });
+    }
   } else if (pathname.startsWith('/til')) {
     breadcrumbs.push({ text: 'Today I Learned', href: '/til', icon: 'tabler:bulb' });
 
@@ -465,6 +485,12 @@ export function getNavigationContext(pathname: string): {
   // Blog posts have /blog as parent
   if (pathname.startsWith('/blog/') && pathname !== '/blog') {
     const parent = SITE_STRUCTURE['/blog'];
+    return { parent, siblings: [], children: [] };
+  }
+
+  // Writing entries have /writing as parent
+  if (pathname.startsWith('/writing/') && pathname !== '/writing') {
+    const parent = SITE_STRUCTURE['/writing'];
     return { parent, siblings: [], children: [] };
   }
 


### PR DESCRIPTION
## Summary
- Adds a `/writing` section that renders editorial essays exported from the Frequency Music sister project via a custom Astro content loader (`githubEditorialLoader`)
- Cross-lists editorial entries in the `/blog` listing and RSS feed, with a "Writing" category and kind-based tags
- Adds navigation links, breadcrumbs, internal linking support, and canonical URLs for SEO

## Test plan
- [ ] Run `bun run dev` and verify `/writing` renders the fixture entry
- [ ] Visit `/blog` and confirm the editorial entry appears with "Writing" category
- [ ] Click the editorial entry in `/blog` — should navigate to `/writing/phase-four-fixture`
- [ ] On the detail page, verify the canonical meta tag points to the Frequency Music app URL
- [ ] Check `/rss.xml` includes the editorial entry without duplicates
- [ ] Run `bun run build` — should complete with no errors
- [ ] Set `EDITORIAL_MANIFEST_URL` env var on Vercel for production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Writing" section with header/footer links, index and article pages, and article views showing metadata, "Why It Matters", uncertainty, and source link.
  * New editorial content collection surfaced in site listings and global content feeds; editorial items are ingested from an exported manifest and rendered as articles.
  * Editorial items integrated into blog listings while being excluded from certain blog path generation.

* **Documentation**
  * Architecture docs updated to describe the editorial content collection.

* **Style**
  * Normalized RSS feed apostrophe/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->