### PR TITLE
feat: load frequency essays into blog posts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,10 @@
 import { defineCollection, z } from "astro:content";
 import { file, glob, type Loader } from "astro/loaders";
 import { existsSync } from "node:fs";
-import type { NotionLoaderOptions } from "../vendor/notion-astro-loader/src/loader.js";
-import { frequencyEssayLoader } from "./loaders/frequencyEssayLoader";
-import { githubEditorialLoader } from "./loaders/githubEditorialLoader";
-import { mergeLoaders } from "./loaders/mergeLoaders";
+import type { NotionLoaderOptions } from "~/vendor/notionLoader";
+import { frequencyEssayLoader } from "~/loaders/frequencyEssayLoader";
+import { githubEditorialLoader } from "~/loaders/githubEditorialLoader";
+import { mergeLoaders } from "~/loaders/mergeLoaders";
 
 const parseResourcesCache = (
   source: string,
@@ -55,8 +55,8 @@ let notionLoaderFactory: ((options: NotionLoaderOptions) => Loader) | null =
   null;
 if (!isDevServer) {
   try {
-    const module = await import("../vendor/notion-astro-loader/src/loader.js");
-    notionLoaderFactory = module.notionLoader;
+    const { notionLoader } = await import("~/vendor/notionLoader");
+    notionLoaderFactory = notionLoader;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,14 @@
-import { defineCollection, z } from 'astro:content';
-import { file, glob, type Loader } from 'astro/loaders';
-import { existsSync } from 'node:fs';
-import type { NotionLoaderOptions } from '../vendor/notion-astro-loader/src/loader.js';
-import { githubEditorialLoader } from './loaders/githubEditorialLoader';
+import { defineCollection, z } from "astro:content";
+import { file, glob, type Loader } from "astro/loaders";
+import { existsSync } from "node:fs";
+import type { NotionLoaderOptions } from "../vendor/notion-astro-loader/src/loader.js";
+import { frequencyEssayLoader } from "./loaders/frequencyEssayLoader";
+import { githubEditorialLoader } from "./loaders/githubEditorialLoader";
+import { mergeLoaders } from "./loaders/mergeLoaders";
 
-const parseResourcesCache = (source: string): Array<Record<string, unknown>> => {
+const parseResourcesCache = (
+  source: string,
+): Array<Record<string, unknown>> => {
   let payload: unknown;
   try {
     payload = JSON.parse(source) as unknown;
@@ -18,8 +22,10 @@ const parseResourcesCache = (source: string): Array<Record<string, unknown>> => 
 
   return payload.map((item, index) => {
     const value = item as Record<string, unknown>;
-    const id = typeof value.id === 'string' && value.id ? value.id : `cache-${index}`;
-    const sourceData = (value.data as Record<string, unknown> | undefined) ?? value;
+    const id =
+      typeof value.id === "string" && value.id ? value.id : `cache-${index}`;
+    const sourceData =
+      (value.data as Record<string, unknown> | undefined) ?? value;
     return {
       ...sourceData,
       id,
@@ -27,13 +33,13 @@ const parseResourcesCache = (source: string): Array<Record<string, unknown>> => 
   });
 };
 
-const resourcesCachePath = 'src/content/resources-cache.json';
+const resourcesCachePath = "src/content/resources-cache.json";
 const resourcesCacheFileLoader = file(resourcesCachePath, {
   parser: parseResourcesCache,
 });
 const fallbackResourcesLoader: Loader = {
-  name: 'resources-fallback-loader',
-  load: async context => {
+  name: "resources-fallback-loader",
+  load: async (context) => {
     const resourcesCacheUrl = new URL(resourcesCachePath, context.config.root);
     if (!existsSync(resourcesCacheUrl)) {
       context.store.clear();
@@ -45,18 +51,24 @@ const fallbackResourcesLoader: Loader = {
 };
 const isDevServer = import.meta.env.DEV;
 
-let notionLoaderFactory: ((options: NotionLoaderOptions) => Loader) | null = null;
+let notionLoaderFactory: ((options: NotionLoaderOptions) => Loader) | null =
+  null;
 if (!isDevServer) {
   try {
-    const module = await import('../vendor/notion-astro-loader/src/loader.js');
+    const module = await import("../vendor/notion-astro-loader/src/loader.js");
     notionLoaderFactory = module.notionLoader;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[resources-notion-loader] Falling back to cache loader: ${message}`);
+    console.warn(
+      `[resources-notion-loader] Falling back to cache loader: ${message}`,
+    );
   }
 }
 
-const createNotionResourcesLoader = (auth: string, databaseId: string): Loader => {
+const createNotionResourcesLoader = (
+  auth: string,
+  databaseId: string,
+): Loader => {
   if (!notionLoaderFactory) {
     return fallbackResourcesLoader;
   }
@@ -64,10 +76,10 @@ const createNotionResourcesLoader = (auth: string, databaseId: string): Loader =
   return notionLoaderFactory({
     auth,
     database_id: databaseId,
-    imageSavePath: 'content/notion/images',
+    imageSavePath: "content/notion/images",
     filter: {
-      property: 'Status',
-      status: { equals: 'Up-to-Date' },
+      property: "Status",
+      status: { equals: "Up-to-Date" },
     },
   });
 };
@@ -100,7 +112,7 @@ const metadataDefinition = () =>
                 url: z.string(),
                 width: z.number().optional(),
                 height: z.number().optional(),
-              })
+              }),
             )
             .optional(),
           locale: z.string().optional(),
@@ -119,7 +131,10 @@ const metadataDefinition = () =>
     .optional();
 
 const postCollection = defineCollection({
-  loader: glob({ pattern: ['**/*.md', '**/*.mdx'], base: 'src/content/post' }),
+  loader: mergeLoaders(
+    glob({ pattern: ["**/*.md", "**/*.mdx"], base: "src/content/post" }),
+    frequencyEssayLoader(),
+  ),
   schema: ({ image }) =>
     z.object({
       publishDate: z.date().optional(),
@@ -133,13 +148,14 @@ const postCollection = defineCollection({
       category: z.string().optional(),
       tags: z.array(z.string()).optional(),
       author: z.string().optional(),
+      byline: z.string().optional(),
 
       metadata: metadataDefinition(),
     }),
 });
 
 const tilCollection = defineCollection({
-  loader: glob({ pattern: ['**/*.md', '**/*.mdx'], base: 'src/content/til' }),
+  loader: glob({ pattern: ["**/*.md", "**/*.mdx"], base: "src/content/til" }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),
@@ -157,10 +173,15 @@ const editorialCollection = defineCollection({
   schema: z.object({
     title: z.string(),
     slug: z.string(),
-    kind: z.enum(['experiment_recap', 'what_changed_my_mind', 'campaign_summary', 'thesis_summary']),
+    kind: z.enum([
+      "experiment_recap",
+      "what_changed_my_mind",
+      "campaign_summary",
+      "thesis_summary",
+    ]),
     publishedAt: z.coerce.date(),
     dek: z.string(),
-    evidenceStatus: z.enum(['supported', 'mixed', 'speculative']),
+    evidenceStatus: z.enum(["supported", "mixed", "speculative"]),
     uncertaintySummary: z.string(),
     whyItMatters: z.string(),
     campaignSlug: z.string().optional(),
@@ -185,36 +206,40 @@ export const collections = {
     loader: resourcesLoader,
     // Schema: start from Notion property types; refine as needed
     schema: z.object({
-        // Include raw Notion properties so we can derive titles when needed
-        properties: z.any().optional(),
-        // Flattened map of all property values for convenient access
-        flat: z.record(z.string(), z.unknown()).optional(),
-        rawTransformedProperties: z.record(z.string(), z.unknown()).optional(),
-        Name: z.string().optional(),
-        Source: z.string().url().optional(),
-        'User Defined URL': z.string().url().optional(),
-        Category: z.array(z.string()).optional(),
-        Type: z.array(z.string()).optional(),
-        Tags: z.array(z.string()).optional(),
-        Keywords: z.array(z.string()).optional(),
-        Status: z.enum(['Needs Review', 'Writing', 'Needs Update', 'Up-to-Date']).optional(),
-        Length: z.enum(['Short', 'Medium', 'Long']).optional(),
-        'AI summary': z.string().optional(),
-        'Last Updated': z
-          .union([
-            z.date(),
-            z.string(),
-            z
-              .object({
-                start: z.date().optional(),
-                end: z.date().nullable(),
-                time_zone: z.string().nullable(),
-              })
-              .nullable(),
-          ])
-          .optional(),
-        'Skill Level': z.enum(['Beginner', 'Intermediate', 'Advanced', 'Any']).optional(),
-        Favorite: z.boolean().optional(),
-      }),
+      // Include raw Notion properties so we can derive titles when needed
+      properties: z.any().optional(),
+      // Flattened map of all property values for convenient access
+      flat: z.record(z.string(), z.unknown()).optional(),
+      rawTransformedProperties: z.record(z.string(), z.unknown()).optional(),
+      Name: z.string().optional(),
+      Source: z.string().url().optional(),
+      "User Defined URL": z.string().url().optional(),
+      Category: z.array(z.string()).optional(),
+      Type: z.array(z.string()).optional(),
+      Tags: z.array(z.string()).optional(),
+      Keywords: z.array(z.string()).optional(),
+      Status: z
+        .enum(["Needs Review", "Writing", "Needs Update", "Up-to-Date"])
+        .optional(),
+      Length: z.enum(["Short", "Medium", "Long"]).optional(),
+      "AI summary": z.string().optional(),
+      "Last Updated": z
+        .union([
+          z.date(),
+          z.string(),
+          z
+            .object({
+              start: z.date().optional(),
+              end: z.date().nullable(),
+              time_zone: z.string().nullable(),
+            })
+            .nullable(),
+        ])
+        .optional(),
+      "Skill Level": z
+        .enum(["Beginner", "Intermediate", "Advanced", "Any"])
+        .optional(),
+      Favorite: z.boolean().optional(),
+    }),
   }),
 };

--- a/src/loaders/frequencyEssayLoader.ts
+++ b/src/loaders/frequencyEssayLoader.ts
@@ -1,0 +1,164 @@
+import type { Loader } from 'astro/loaders';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
+
+type EssayManifestItem = {
+  slug: string;
+  path: string;
+  title: string;
+  publishDate: string | null;
+  category: string;
+};
+
+type EssayManifest = {
+  version: 'frequency_essays_v1';
+  generatedAt: string;
+  items: EssayManifestItem[];
+};
+
+type ManifestSource =
+  | {
+      mode: 'remote';
+      manifestUrl: URL;
+      contentBaseUrl: URL;
+      manifest: EssayManifest;
+    }
+  | {
+      mode: 'local';
+      baseDir: string;
+      manifest: EssayManifest;
+    };
+
+const DEFAULT_LOCAL_EXPORT_DIR = resolve(process.cwd(), '../frequency-music/exports/blog');
+
+function parseManifest(raw: string): EssayManifest {
+  const parsed = JSON.parse(raw) as Partial<EssayManifest>;
+  if (parsed.version !== 'frequency_essays_v1' || !Array.isArray(parsed.items)) {
+    throw new Error('Essay manifest is missing the frequency_essays_v1 contract.');
+  }
+  return parsed as EssayManifest;
+}
+
+function parseMarkdownDocument(source: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) {
+    throw new Error('Essay markdown file is missing frontmatter.');
+  }
+
+  return {
+    frontmatter: loadYaml(match[1] ?? '') as Record<string, unknown>,
+    body: match[2] ?? '',
+  };
+}
+
+async function fetchText(url: URL): Promise<string> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url.toString()}: ${response.status} ${response.statusText}`);
+  }
+  return await response.text();
+}
+
+async function loadManifestSource(): Promise<ManifestSource | null> {
+  const manifestUrl = process.env.ESSAY_MANIFEST_URL;
+  if (manifestUrl) {
+    const manifestLocation = new URL(manifestUrl);
+    const contentBaseUrl = process.env.ESSAY_CONTENT_BASE_URL
+      ? new URL(process.env.ESSAY_CONTENT_BASE_URL)
+      : new URL('./', manifestLocation);
+    const manifest = parseManifest(await fetchText(manifestLocation));
+    return {
+      mode: 'remote',
+      manifestUrl: manifestLocation,
+      contentBaseUrl,
+      manifest,
+    };
+  }
+
+  const localBaseDir = process.env.ESSAY_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
+  const manifestPath = join(localBaseDir, 'manifest.json');
+
+  let manifestRaw: string;
+  try {
+    manifestRaw = await readFile(manifestPath, 'utf8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+
+  return {
+    mode: 'local',
+    baseDir: localBaseDir,
+    manifest: parseManifest(manifestRaw),
+  };
+}
+
+async function loadMarkdownEntry(
+  source: ManifestSource,
+  relativePath: string
+): Promise<{ raw: string; fileUrl?: URL }> {
+  if (source.mode === 'remote') {
+    const url = new URL(relativePath, source.contentBaseUrl);
+    return { raw: await fetchText(url), fileUrl: url };
+  }
+
+  const filePath = join(source.baseDir, relativePath);
+  return {
+    raw: await readFile(filePath, 'utf8'),
+    fileUrl: pathToFileURL(filePath),
+  };
+}
+
+export function frequencyEssayLoader(): Loader {
+  return {
+    name: 'frequency-essay-loader',
+    load: async context => {
+      const source = await loadManifestSource();
+
+      if (!source) {
+        context.logger.warn(
+          'No essay manifest found. Set ESSAY_MANIFEST_URL or run export-essays.ts in frequency-music.'
+        );
+        return;
+      }
+
+      for (const item of source.manifest.items) {
+        try {
+          const { raw, fileUrl } = await loadMarkdownEntry(source, item.path);
+          const { frontmatter, body } = parseMarkdownDocument(raw);
+          const parsedData = await context.parseData({
+            id: `essay/${item.slug}`,
+            data: frontmatter,
+          });
+          const rendered = await context.renderMarkdown(body, {
+            fileURL: fileUrl,
+          });
+          context.store.set({
+            id: `essay/${item.slug}`,
+            data: parsedData,
+            body,
+            digest: context.generateDigest(raw),
+            rendered,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          context.logger.error(`Failed to load essay ${item.slug}: ${message}`);
+        }
+      }
+    },
+  };
+}

--- a/src/loaders/frequencyEssayLoader.ts
+++ b/src/loaders/frequencyEssayLoader.ts
@@ -1,6 +1,6 @@
 import type { Loader } from 'astro/loaders';
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
 
@@ -77,8 +77,9 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
   const manifestUrl = process.env.ESSAY_MANIFEST_URL;
   if (manifestUrl) {
     const manifestLocation = new URL(manifestUrl);
-    const contentBaseUrl = process.env.ESSAY_CONTENT_BASE_URL
-      ? new URL(process.env.ESSAY_CONTENT_BASE_URL)
+    const rawContentBaseUrl = process.env.ESSAY_CONTENT_BASE_URL;
+    const contentBaseUrl = rawContentBaseUrl
+      ? new URL(rawContentBaseUrl.endsWith('/') ? rawContentBaseUrl : `${rawContentBaseUrl}/`)
       : new URL('./', manifestLocation);
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {
@@ -113,10 +114,20 @@ async function loadMarkdownEntry(
 ): Promise<{ raw: string; fileUrl?: URL }> {
   if (source.mode === 'remote') {
     const url = new URL(relativePath, source.contentBaseUrl);
+    const basePath = source.contentBaseUrl.pathname.endsWith('/')
+      ? source.contentBaseUrl.pathname
+      : `${source.contentBaseUrl.pathname}/`;
+    if (url.origin !== source.contentBaseUrl.origin || !url.pathname.startsWith(basePath)) {
+      throw new Error(`Essay path escapes content base: ${relativePath}`);
+    }
     return { raw: await fetchText(url), fileUrl: url };
   }
 
-  const filePath = join(source.baseDir, relativePath);
+  const baseDir = resolve(source.baseDir);
+  const filePath = resolve(baseDir, relativePath);
+  if (filePath !== baseDir && !filePath.startsWith(`${baseDir}${sep}`)) {
+    throw new Error(`Essay path escapes export directory: ${relativePath}`);
+  }
   return {
     raw: await readFile(filePath, 'utf8'),
     fileUrl: pathToFileURL(filePath),

--- a/src/loaders/frequencyEssayLoader.ts
+++ b/src/loaders/frequencyEssayLoader.ts
@@ -78,9 +78,16 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
   if (manifestUrl) {
     const manifestLocation = new URL(manifestUrl);
     const rawContentBaseUrl = process.env.ESSAY_CONTENT_BASE_URL;
-    const contentBaseUrl = rawContentBaseUrl
-      ? new URL(rawContentBaseUrl.endsWith('/') ? rawContentBaseUrl : `${rawContentBaseUrl}/`)
-      : new URL('./', manifestLocation);
+    let contentBaseUrl: URL;
+    if (rawContentBaseUrl) {
+      const parsedUrl = new URL(rawContentBaseUrl);
+      if (!parsedUrl.pathname.endsWith('/')) {
+        parsedUrl.pathname += '/';
+      }
+      contentBaseUrl = parsedUrl;
+    } else {
+      contentBaseUrl = new URL('./', manifestLocation);
+    }
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {
       mode: 'remote',

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -80,9 +80,16 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
   if (manifestUrl) {
     const manifestLocation = new URL(manifestUrl);
     const rawContentBaseUrl = process.env.EDITORIAL_CONTENT_BASE_URL;
-    const contentBaseUrl = rawContentBaseUrl
-      ? new URL(rawContentBaseUrl.endsWith('/') ? rawContentBaseUrl : `${rawContentBaseUrl}/`)
-      : new URL('./', manifestLocation);
+    let contentBaseUrl: URL;
+    if (rawContentBaseUrl) {
+      const parsedUrl = new URL(rawContentBaseUrl);
+      if (!parsedUrl.pathname.endsWith('/')) {
+        parsedUrl.pathname += '/';
+      }
+      contentBaseUrl = parsedUrl;
+    } else {
+      contentBaseUrl = new URL('./', manifestLocation);
+    }
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {
       mode: 'remote',

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -79,8 +79,9 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
   const manifestUrl = process.env.EDITORIAL_MANIFEST_URL;
   if (manifestUrl) {
     const manifestLocation = new URL(manifestUrl);
-    const contentBaseUrl = process.env.EDITORIAL_CONTENT_BASE_URL
-      ? new URL(process.env.EDITORIAL_CONTENT_BASE_URL)
+    const rawContentBaseUrl = process.env.EDITORIAL_CONTENT_BASE_URL;
+    const contentBaseUrl = rawContentBaseUrl
+      ? new URL(rawContentBaseUrl.endsWith('/') ? rawContentBaseUrl : `${rawContentBaseUrl}/`)
       : new URL('./', manifestLocation);
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {

--- a/src/loaders/mergeLoaders.ts
+++ b/src/loaders/mergeLoaders.ts
@@ -1,0 +1,12 @@
+import type { Loader } from 'astro/loaders';
+
+export function mergeLoaders(...loaders: Loader[]): Loader {
+  return {
+    name: loaders.map(loader => loader.name).join('+'),
+    load: async context => {
+      for (const loader of loaders) {
+        await loader.load(context);
+      }
+    },
+  };
+}

--- a/src/vendor/notionLoader.ts
+++ b/src/vendor/notionLoader.ts
@@ -1,0 +1,2 @@
+export type { NotionLoaderOptions } from "../../vendor/notion-astro-loader/src/loader.js";
+export { notionLoader } from "../../vendor/notion-astro-loader/src/loader.js";


### PR DESCRIPTION
## Summary
- add a frequency essay loader that reads the exported essay manifest and markdown from `frequency-music`
- merge imported essays into the existing `post` collection and add optional `byline` support for rendered author display
- support local and remote manifest loading so the website can consume generated essay exports in development and production

## Verification
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for loading "frequency essay" content from configured remote or local manifests.
  * Optional byline added to posts.

* **Refactor**
  * Combined multiple content loaders so essays and existing posts are processed together.
  * Content schemas and enum literals reformatted for consistency.

* **Chores**
  * Export shims added for a third‑party content loader to simplify imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->