### PR TITLE
refactor: simplify frequency content loading to use single base URL

### DIFF
--- a/src/loaders/frequencyEssayLoader.ts
+++ b/src/loaders/frequencyEssayLoader.ts
@@ -84,10 +84,10 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
       manifest,
     };
   } catch {
-    // Remote fetch failed, try local mode if FREQUENCY_LOCAL_EXPORT_DIR is set
+    // Remote fetch failed
   }
 
-  if (FREQUENCY_EXPORTS_DIR) {
+  if (FREQUENCY_EXPORTS_DIR !== null) {
     const manifestPath = join(FREQUENCY_EXPORTS_DIR, 'blog', 'manifest.json');
 
     let manifestRaw: string;
@@ -156,7 +156,7 @@ export function frequencyEssayLoader(): Loader {
             data: frontmatter,
           });
           const rendered = await context.renderMarkdown(body, {
-            fileURL: fileUrl,
+            fileURL: source.mode === 'local' ? fileUrl : undefined,
           });
           context.store.set({
             id: `essay/${item.slug}`,

--- a/src/loaders/frequencyEssayLoader.ts
+++ b/src/loaders/frequencyEssayLoader.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
+import { FREQUENCY_EXPORTS_DIR, getEssayContentBaseUrl, getEssayManifestUrl } from '~/utils/frequency';
 
 type EssayManifestItem = {
   slug: string;
@@ -30,8 +31,6 @@ type ManifestSource =
       baseDir: string;
       manifest: EssayManifest;
     };
-
-const DEFAULT_LOCAL_EXPORT_DIR = resolve(process.cwd(), '../frequency-music/exports/blog');
 
 function parseManifest(raw: string): EssayManifest {
   const parsed = JSON.parse(raw) as Partial<EssayManifest>;
@@ -74,20 +73,9 @@ async function fetchText(url: URL): Promise<string> {
 }
 
 async function loadManifestSource(): Promise<ManifestSource | null> {
-  const manifestUrl = process.env.ESSAY_MANIFEST_URL;
-  if (manifestUrl) {
-    const manifestLocation = new URL(manifestUrl);
-    const rawContentBaseUrl = process.env.ESSAY_CONTENT_BASE_URL;
-    let contentBaseUrl: URL;
-    if (rawContentBaseUrl) {
-      const parsedUrl = new URL(rawContentBaseUrl);
-      if (!parsedUrl.pathname.endsWith('/')) {
-        parsedUrl.pathname += '/';
-      }
-      contentBaseUrl = parsedUrl;
-    } else {
-      contentBaseUrl = new URL('./', manifestLocation);
-    }
+  const manifestLocation = getEssayManifestUrl();
+  const contentBaseUrl = getEssayContentBaseUrl();
+  try {
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {
       mode: 'remote',
@@ -95,24 +83,29 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
       contentBaseUrl,
       manifest,
     };
+  } catch {
+    // Remote fetch failed, try local mode if FREQUENCY_LOCAL_EXPORT_DIR is set
   }
 
-  const localBaseDir = process.env.ESSAY_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
-  const manifestPath = join(localBaseDir, 'manifest.json');
+  if (FREQUENCY_EXPORTS_DIR) {
+    const manifestPath = join(FREQUENCY_EXPORTS_DIR, 'blog', 'manifest.json');
 
-  let manifestRaw: string;
-  try {
-    manifestRaw = await readFile(manifestPath, 'utf8');
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
+    let manifestRaw: string;
+    try {
+      manifestRaw = await readFile(manifestPath, 'utf8');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+
+    return {
+      mode: 'local',
+      baseDir: join(FREQUENCY_EXPORTS_DIR, 'blog'),
+      manifest: parseManifest(manifestRaw),
+    };
   }
 
-  return {
-    mode: 'local',
-    baseDir: localBaseDir,
-    manifest: parseManifest(manifestRaw),
-  };
+  return null;
 }
 
 async function loadMarkdownEntry(
@@ -149,7 +142,7 @@ export function frequencyEssayLoader(): Loader {
 
       if (!source) {
         context.logger.warn(
-          'No essay manifest found. Set ESSAY_MANIFEST_URL or run export-essays.ts in frequency-music.'
+          'No essay manifest found. Check network access or set FREQUENCY_LOCAL_EXPORT_DIR for local development.'
         );
         return;
       }

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -86,10 +86,10 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
       manifest,
     };
   } catch {
-    // Remote fetch failed, try local mode if FREQUENCY_LOCAL_EXPORT_DIR is set
+    // Remote fetch failed
   }
 
-  if (FREQUENCY_EXPORTS_DIR) {
+  if (FREQUENCY_EXPORTS_DIR !== null) {
     const manifestPath = join(FREQUENCY_EXPORTS_DIR, 'public-editorial', 'v1', 'manifest.json');
 
     let manifestRaw: string;
@@ -161,7 +161,9 @@ export function githubEditorialLoader(): Loader {
             id: item.slug,
             data: frontmatter,
           });
-          const rendered = await context.renderMarkdown(body, { fileURL: fileUrl });
+          const rendered = await context.renderMarkdown(body, {
+            fileURL: source.mode === 'local' ? fileUrl : undefined,
+          });
           context.store.set({
             id: item.slug,
             data: parsedData,

--- a/src/loaders/githubEditorialLoader.ts
+++ b/src/loaders/githubEditorialLoader.ts
@@ -1,8 +1,9 @@
 import type { Loader } from 'astro/loaders';
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
+import { FREQUENCY_EXPORTS_DIR, getEditorialContentBaseUrl, getEditorialManifestUrl } from '~/utils/frequency';
 
 type EditorialManifestEntry = {
   slug: string;
@@ -31,8 +32,6 @@ type ManifestSource =
       baseDir: string;
       manifest: EditorialManifest;
     };
-
-const DEFAULT_LOCAL_EXPORT_DIR = resolve(process.cwd(), '../frequency-music/exports/public-editorial/v1');
 
 function parseManifest(raw: string): EditorialManifest {
   const parsed = JSON.parse(raw) as Partial<EditorialManifest>;
@@ -76,20 +75,9 @@ async function fetchText(url: URL): Promise<string> {
 }
 
 async function loadManifestSource(): Promise<ManifestSource | null> {
-  const manifestUrl = process.env.EDITORIAL_MANIFEST_URL;
-  if (manifestUrl) {
-    const manifestLocation = new URL(manifestUrl);
-    const rawContentBaseUrl = process.env.EDITORIAL_CONTENT_BASE_URL;
-    let contentBaseUrl: URL;
-    if (rawContentBaseUrl) {
-      const parsedUrl = new URL(rawContentBaseUrl);
-      if (!parsedUrl.pathname.endsWith('/')) {
-        parsedUrl.pathname += '/';
-      }
-      contentBaseUrl = parsedUrl;
-    } else {
-      contentBaseUrl = new URL('./', manifestLocation);
-    }
+  const manifestLocation = getEditorialManifestUrl();
+  const contentBaseUrl = getEditorialContentBaseUrl();
+  try {
     const manifest = parseManifest(await fetchText(manifestLocation));
     return {
       mode: 'remote',
@@ -97,25 +85,30 @@ async function loadManifestSource(): Promise<ManifestSource | null> {
       contentBaseUrl,
       manifest,
     };
+  } catch {
+    // Remote fetch failed, try local mode if FREQUENCY_LOCAL_EXPORT_DIR is set
   }
 
-  const localBaseDir = process.env.EDITORIAL_LOCAL_EXPORT_DIR ?? DEFAULT_LOCAL_EXPORT_DIR;
-  const manifestPath = join(localBaseDir, 'manifest.json');
+  if (FREQUENCY_EXPORTS_DIR) {
+    const manifestPath = join(FREQUENCY_EXPORTS_DIR, 'public-editorial', 'v1', 'manifest.json');
 
-  let manifestRaw: string;
-  try {
-    manifestRaw = await readFile(manifestPath, 'utf8');
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
+    let manifestRaw: string;
+    try {
+      manifestRaw = await readFile(manifestPath, 'utf8');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+
+    const manifest = parseManifest(manifestRaw);
+    return {
+      mode: 'local',
+      baseDir: join(FREQUENCY_EXPORTS_DIR, 'public-editorial', 'v1'),
+      manifest,
+    };
   }
 
-  const manifest = parseManifest(manifestRaw);
-  return {
-    mode: 'local',
-    baseDir: localBaseDir,
-    manifest,
-  };
+  return null;
 }
 
 async function loadMarkdownEntry(
@@ -124,10 +117,20 @@ async function loadMarkdownEntry(
 ): Promise<{ raw: string; fileUrl?: URL }> {
   if (source.mode === 'remote') {
     const url = new URL(relativePath, source.contentBaseUrl);
+    const basePath = source.contentBaseUrl.pathname.endsWith('/')
+      ? source.contentBaseUrl.pathname
+      : `${source.contentBaseUrl.pathname}/`;
+    if (url.origin !== source.contentBaseUrl.origin || !url.pathname.startsWith(basePath)) {
+      throw new Error(`Editorial path escapes content base: ${relativePath}`);
+    }
     return { raw: await fetchText(url), fileUrl: url };
   }
 
-  const filePath = join(source.baseDir, relativePath);
+  const baseDir = resolve(source.baseDir);
+  const filePath = resolve(baseDir, relativePath);
+  if (filePath !== baseDir && !filePath.startsWith(`${baseDir}${sep}`)) {
+    throw new Error(`Editorial path escapes export directory: ${relativePath}`);
+  }
   return {
     raw: await readFile(filePath, 'utf8'),
     fileUrl: pathToFileURL(filePath),
@@ -143,7 +146,7 @@ export function githubEditorialLoader(): Loader {
       if (!source) {
         context.store.clear();
         context.logger.warn(
-          'No editorial manifest configured. Set EDITORIAL_MANIFEST_URL or provide a local export snapshot.'
+          'No editorial manifest found. Check network access or set FREQUENCY_LOCAL_EXPORT_DIR for local development.'
         );
         return;
       }

--- a/src/utils/frequency.ts
+++ b/src/utils/frequency.ts
@@ -1,10 +1,10 @@
-import { resolve } from 'node:path';
-
 export const FREQUENCY_GITHUB_RAW = 'https://raw.githubusercontent.com/Resonant-Projects/frequency-music/main';
 
-export const FREQUENCY_EXPORTS_DIR = process.env.FREQUENCY_LOCAL_EXPORT_DIR
-  ? resolve(process.cwd(), process.env.FREQUENCY_LOCAL_EXPORT_DIR)
-  : resolve(process.cwd(), '../frequency-music/exports');
+export const FREQUENCY_EXPORTS_DIR: string | null = (() => {
+  const localExportDir = process.env.FREQUENCY_LOCAL_EXPORT_DIR;
+  if (!localExportDir) return null;
+  return localExportDir;
+})();
 
 export function getEssayManifestUrl(): URL {
   return new URL(`${FREQUENCY_GITHUB_RAW}/exports/blog/manifest.json`);

--- a/src/utils/frequency.ts
+++ b/src/utils/frequency.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+
+export const FREQUENCY_GITHUB_RAW = 'https://raw.githubusercontent.com/Resonant-Projects/frequency-music/main';
+
+export const FREQUENCY_EXPORTS_DIR = process.env.FREQUENCY_LOCAL_EXPORT_DIR
+  ? resolve(process.cwd(), process.env.FREQUENCY_LOCAL_EXPORT_DIR)
+  : resolve(process.cwd(), '../frequency-music/exports');
+
+export function getEssayManifestUrl(): URL {
+  return new URL(`${FREQUENCY_GITHUB_RAW}/exports/blog/manifest.json`);
+}
+
+export function getEssayContentBaseUrl(): URL {
+  return new URL(`${FREQUENCY_GITHUB_RAW}/exports/blog/`);
+}
+
+export function getEditorialManifestUrl(): URL {
+  return new URL(`${FREQUENCY_GITHUB_RAW}/exports/public-editorial/v1/manifest.json`);
+}
+
+export function getEditorialContentBaseUrl(): URL {
+  return new URL(`${FREQUENCY_GITHUB_RAW}/exports/public-editorial/v1/`);
+}


### PR DESCRIPTION
- Add src/utils/frequency.ts with hardcoded GitHub raw URL
- Both essay and editorial loaders now use shared path helpers
- Remove ESSAY_MANIFEST_URL, ESSAY_CONTENT_BASE_URL, EDITORIAL_MANIFEST_URL, EDITORIAL_CONTENT_BASE_URL
- Add FREQUENCY_LOCAL_EXPORT_DIR for optional local development
- Add path validation to githubEditorialLoader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest loading now reliably tries remote sources first, falling back to local exports when needed.
  * Stronger path validation prevents serving content outside expected locations, reducing load errors.

* **Documentation**
  * Clarified warning text and configuration guidance for local development and network-related manifest issues.

* **Behavior**
  * Rendering now consistently handles remote vs. local content to improve display reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->