### PR TITLE
Add opencode workflow and improve category card spacing

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          model: openai/gpt-5.4-mini

--- a/src/pages/category.astro
+++ b/src/pages/category.astro
@@ -32,7 +32,7 @@ const metadata = {
       allCategories.length > 0 ? (
         <div class="-up grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
           {allCategories.map(category => (
-            <article class="group relative overflow-hidden rounded-lg border shadow-sm transition-all hover:shadow-md">
+            <article class="group relative overflow-hidden rounded-lg border p-4 shadow-sm transition-all hover:shadow-md">
               <div class="flex h-full flex-col">
                 <h3 class="heading-md mb-3 text-foreground group-hover:text-primary">
                   <a href={`${getBlogCategoryPermalink()}/${category.slug}`} class="stretched-link focus-ring">


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that triggers `opencode` from issue and PR comments using `/oc` or `/opencode` commands.
- Run the workflow with `openai/gpt-5.4-mini` and the repository's `OPENAI_API_KEY` secret.
- Add padding to category cards on the category listing page for better spacing and readability.

## Testing
- Not run (workflow/config and small UI spacing change only).
- Reviewed the diff to confirm the new workflow triggers and permissions are set correctly.
- Confirmed the category card update only adds internal padding in `src/pages/category.astro`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing on category tiles for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->