### PR TITLE
Remove responsive flex display from announcement bar

### DIFF
--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -3,7 +3,7 @@
 ---
 
 <div
-  class="bg-muted/40 relative hidden gap-1 overflow-hidden text-ellipsis whitespace-nowrap border-b border-border px-3 py-2 text-sm text-foreground md:flex"
+  class="bg-muted/40 relative hidden gap-1 overflow-hidden text-ellipsis whitespace-nowrap border-b border-border px-3 py-2 text-sm text-foreground"
 >
   <span
     class="text-accent-foreground mr-0.5 inline-block rounded-sm bg-accent px-1 py-0.5 text-xs font-semibold rtl:ml-0.5 rtl:mr-0"


### PR DESCRIPTION
## Summary
- Removed the `md:flex` responsive display class from the announcement bar container in `src/components/widgets/Announcement.astro`.
- Keeps the announcement bar hidden by default without enabling the flex layout at medium screens.

## Testing
- Not run (content-only class change).
- Reviewed the diff to confirm only the announcement bar wrapper class list changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the announcement widget's display behavior to remain consistently hidden across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->