### PR TITLE
ci: move the build, a11y and CSS jobs onto the GARM self-hosted pools

### DIFF
--- a/.github/workflows/accessibility-testing.yml
+++ b/.github/workflows/accessibility-testing.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, incus, garm, ephemeral]
     timeout-minutes: 15
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     steps:
@@ -40,7 +40,7 @@ jobs:
   accessibility-tests:
     name: Accessibility Tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, incus, garm, ephemeral]
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-lint:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, incus, garm, ephemeral]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/css-validation.yml
+++ b/.github/workflows/css-validation.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   css-validation:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, incus, garm, ephemeral]
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Moves four jobs from `ubuntu-latest` to the homelab GARM pools:

| workflow | job |
| --- | --- |
| `actions.yaml` | `build-and-lint` |
| `accessibility-testing.yml` | `build` |
| `accessibility-testing.yml` | `accessibility-tests` |
| `css-validation.yml` | `css-validation` |

```yaml
runs-on: [self-hosted, linux, x64, incus, garm, ephemeral]
```

The lab runs GARM v0.2.1 on Incus with ephemeral, scale-to-zero container runners — 4 vCPU / 6 GiB, Docker via `security.nesting` — and this repo already has pools across all three Incus providers. GARM label matching is superset-based, so these land on any of the three.

## Two jobs stay on `ubuntu-latest`

- **`codeql`** — `github/codeql-action` expects the GitHub image's preinstalled CodeQL bundle, and the job holds `security-events: write`. Not worth moving.
- **`opencode`** — this one is worth raising on its own. It triggers on any `issue_comment` / `pull_request_review_comment` containing `/oc` or `/opencode`, with **no author-association guard**, and runs an LLM agent with `OPENAI_API_KEY` in scope. On a LAN runner that would give any commenter a shell inside `172.16.10.0/24`. It arguably needs a guard even where it is today; moving it would make that urgent.

## Security note

This repo is **public**, so fork PRs execute untrusted code. Before making this change I verified:

```
gh api repos/Resonant-Projects/rproj-website/actions/permissions/fork-pr-contributor-approval
→ all_external_contributors
```

so every external fork PR requires manual approval before any workflow runs. The three migrated workflows also already gate their secret-bearing steps on `github.event.pull_request.head.repo.fork == false`. Runner network isolation is still unbuilt, which is what makes that approval gate load-bearing rather than belt-and-braces.

## Trade-off, stated plainly

This repo is public, so GitHub-hosted minutes are already free — the migration saves no money. It costs wall-clock (roughly **+75s** per job for container provisioning, plus Chrome/Puppeteer downloading per ephemeral run instead of being preinstalled) and it puts PR code on the LAN. What it buys is consistency with the rest of the fleet and independence from GitHub-hosted queue times.

Each job is a one-line revert if that trade doesn't hold up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated accessibility, build, lint, and CSS validation workflows to run on ephemeral self-hosted Linux runners.
  * Workflow steps and validation coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->