### PR TITLE
ci: poll for the dev server instead of sleeping a fixed 20s

### DIFF
--- a/.github/workflows/css-validation.yml
+++ b/.github/workflows/css-validation.yml
@@ -75,9 +75,20 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY || 're_ci_dev_placeholder' }}
         run: |
           bun run dev > dev.log 2>&1 &
-          sleep 20
-          cat dev.log
-          curl -f http://localhost:4321 || (cat dev.log && exit 1)
+          # Poll rather than sleeping a fixed 20s. A cold Astro dev start on an
+          # ephemeral runner spends longer than that syncing content before it
+          # binds the port, and the old single curl raced it every time.
+          for i in $(seq 1 45); do
+            if curl -sf http://localhost:4321 > /dev/null; then
+              echo "Dev server is up"; break; fi
+            echo "Waiting for dev server... ($i/45)"
+            sleep 2
+            if [ "$i" -eq 45 ]; then
+              echo "Dev server did not start in time" >&2
+              cat dev.log
+              exit 1
+            fi
+          done
 
       - name: Run contrast validation
         run: bun run test:contrast


### PR DESCRIPTION
## What

`css-validation.yml`'s **Start dev server** step now polls for readiness (45 × 2s) instead of `sleep 20` followed by a single `curl -f`.

## Why

This workflow is path-filtered to stylesheets, so it had effectively never run since the GARM migration. The first manual dispatch (run 30839470658) failed:

```
18:18:19  [content] Syncing content      <- dev server still starting
18:18:25  curl: (7) Failed to connect to localhost port 4321 after 0 ms
```

A cold Astro dev start on an ephemeral runner takes longer than 20s to bind the port. `accessibility-testing.yml` already polls for exactly this reason; this workflow never got the same treatment.

## Verified

Dispatched on this branch: **run 30840785909 — success**, including `test:contrast`, `validate:css` and the visual verification steps.

`dev.log` is now dumped only on timeout rather than unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server readiness checks by retrying for up to 90 seconds.
  * Added clearer startup failure reporting and diagnostic logs when the server is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->