### PR TITLE
fix: stop csso from deleting every responsive utility from the build

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -62,7 +62,15 @@ export default defineConfig({
       config: { forward: ['dataLayer.push'] },
     }),
     compress({
-      CSS: true,
+      // Minify with lightningcss, not csso. Tailwind v4 emits every responsive
+      // variant inside CSS Media Queries Level 4 range syntax — `@media
+      // (width>=64rem)` — which csso 5 cannot parse, so it silently deletes the
+      // whole block. That stripped every `sm:`/`md:`/`lg:` utility from the
+      // build and rendered the site at base (mobile) sizes on all viewports.
+      CSS: {
+        csso: false,
+        lightningcss: { minify: true },
+      },
       HTML: {
         'html-minifier-terser': {
           removeAttributeQuotes: false,


### PR DESCRIPTION
## The bug

Every `sm:`/`md:`/`lg:`/`xl:` utility in the site was being deleted at build time. The site rendered at its **base (mobile) styles on every viewport**, including production.

On https://www.resonantprojects.art the homepage `h1` carries the right classes:

```
text-xl sm:text-3xl md:text-5xl lg:text-6xl
```

…but computes to **20px** at a 1440px viewport instead of 67.5px. The served CSS contains **zero** breakpoint media queries — only feature queries (`prefers-color-scheme`, `hover`, `forced-colors`, `print`).

## Root cause

Tailwind v4 emits every responsive variant using CSS Media Queries Level 4 **range syntax**:

```css
@media (width>=64rem) { .lg\:text-6xl { font-size: 3.75rem } }
```

`astro-compress` with `CSS: true` runs **csso 5.0.5**, which cannot parse that media condition and **silently drops the whole block**. Isolated repro:

```
DROPPED  @media (width >= 40rem){.a{color:red}}
DROPPED  @media (width>=40rem){.a{color:red}}
KEPT     @media (min-width: 40rem){.a{color:red}}
KEPT     @media (hover:hover){.a{color:red}}
```

Only the legacy and feature queries survive — exactly what the built CSS shows.

## The fix

Switch the CSS pass to **lightningcss**, which `astro-compress` already bundles and which parses range syntax correctly.

`csso: false` is set explicitly because the integration deep-merges user options over defaults that enable csso — otherwise both minifiers run in sequence and csso undoes the fix.

## Verification

`main` built three ways, grepping the emitted CSS:

| CSS option | `lg\:text-6xl` | breakpoint `@media` | raw bytes |
|---|---|---|---|
| `true` (csso) | 0 | 0 | 388 KB |
| `false` (none) | 4 | 10 | 443 KB |
| **lightningcss** | **4** | **10** | **443 KB** |

csso's smaller output was not a win — the missing 55 KB *was* the responsive CSS.

Rendered check of the fixed build at 1440×900:

- hero `h1`: **20px → 67.5px**
- desktop nav: restored (was collapsed behind the hamburger)
- hero buttons: inline (were stacked)

## Note on scope

This is **not** a regression from #133 or #134. It reproduces on `main` at 648a6a4 — the local `main` build reproduces production's exact CSS hash (`PageLayout.DPwH6xbu.css`). This should land independently; #134 can rebase on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)