### PR TITLE
test: fail the build when responsive CSS is missing from dist

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,6 +32,11 @@ jobs:
           # fallback css-validation.yml and accessibility-testing.yml carry.
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY || 're_ci_build_placeholder' }}
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      # Catches a CSS minifier silently dropping Tailwind's `@media (width>=…)`
+      # breakpoints, which produces a green build that renders every page at
+      # base (mobile) styles. Must run after the build, against dist/.
+      - run: bun run verify:responsive-css
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
 
   codeql:
     name: Analyze (CodeQL)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:contrast": "node scripts/contrast-checker.js",
     "test:contrast:palette": "node scripts/contrast-checker.js --palette",
     "validate:css": "node scripts/css-variable-validator.js",
+    "verify:responsive-css": "node scripts/verify-responsive-css.js",
     "validate:notion": "node scripts/validate-notion-config.js",
     "test:css-vars": "bun run validate:css",
     "test:all": "bun run test:contrast && bun run validate:css && bun run visual-verify:ci",

--- a/scripts/verify-responsive-css.js
+++ b/scripts/verify-responsive-css.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Responsive CSS Build Verification
+ *
+ * Guards against minifiers silently discarding Tailwind's responsive variants.
+ *
+ * Tailwind v4 emits every `sm:`/`md:`/`lg:`/`xl:`/`2xl:` utility inside CSS
+ * Media Queries Level 4 range syntax — `@media (width>=64rem)`. csso 5 cannot
+ * parse that media condition and drops the whole block without warning, which
+ * once stripped every responsive utility from the production build and left the
+ * site rendering at base (mobile) styles on all viewports. The build still
+ * succeeded and the CSS still looked valid, so nothing caught it.
+ *
+ * This runs against the built CSS and fails loudly if the breakpoints are gone.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+const CSS_DIR = path.resolve(process.cwd(), 'dist/client/_astro');
+
+// Tailwind's default breakpoints, in the range syntax v4 emits. A build that
+// uses any responsive utility at all must contain several of these.
+const MIN_DISTINCT_BREAKPOINTS = 3;
+const MIN_RESPONSIVE_SELECTORS = 10;
+
+// Matches both the modern range syntax Tailwind v4 emits and the legacy form a
+// minifier may lower it to — either is fine, silence is not.
+const BREAKPOINT_MEDIA = /@media[^{]*?\(\s*(?:width\s*[<>]=?|(?:min|max)-width\s*:)[^)]*\)/g;
+const RESPONSIVE_SELECTOR = /\.(?:sm|md|lg|xl|2xl)\\:/g;
+
+async function readCssFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await readCssFiles(full)));
+    else if (entry.name.endsWith('.css')) files.push({ name: entry.name, css: await fs.readFile(full, 'utf8') });
+  }
+  return files;
+}
+
+let files;
+try {
+  files = await readCssFiles(CSS_DIR);
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    console.error(`✗ No built CSS at ${CSS_DIR}\n\n  Run \`bun run build\` before this check.\n`);
+    process.exit(1);
+  }
+  throw error;
+}
+
+if (files.length === 0) {
+  console.error(`✗ No .css files under ${CSS_DIR} — did the build emit any stylesheets?`);
+  process.exit(1);
+}
+
+const breakpoints = new Set();
+let responsiveSelectors = 0;
+
+for (const { css } of files) {
+  for (const match of css.matchAll(BREAKPOINT_MEDIA)) breakpoints.add(match[0].replace(/\s+/g, ''));
+  responsiveSelectors += (css.match(RESPONSIVE_SELECTOR) ?? []).length;
+}
+
+const problems = [];
+if (breakpoints.size < MIN_DISTINCT_BREAKPOINTS) {
+  problems.push(
+    `expected at least ${MIN_DISTINCT_BREAKPOINTS} distinct breakpoint media queries, found ${breakpoints.size}`
+  );
+}
+if (responsiveSelectors < MIN_RESPONSIVE_SELECTORS) {
+  problems.push(
+    `expected at least ${MIN_RESPONSIVE_SELECTORS} responsive utility selectors, found ${responsiveSelectors}`
+  );
+}
+
+if (problems.length > 0) {
+  console.error(`✗ Responsive CSS missing from the build (${files.length} CSS files checked)\n`);
+  for (const problem of problems) console.error(`  · ${problem}`);
+  console.error(
+    `\n  The most likely cause is a CSS minifier discarding \`@media (width>=…)\`` +
+      `\n  blocks it cannot parse. See the CSS option passed to astro-compress in` +
+      `\n  astro.config.ts — csso does not support range syntax; lightningcss does.\n`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ Responsive CSS intact — ${breakpoints.size} breakpoints, ` +
+    `${responsiveSelectors} responsive selectors across ${files.length} CSS files.`
+);


### PR DESCRIPTION
Follow-up to #135.

## Why

The csso bug fixed in #135 produced a **completely green build** — `astro check`, ESLint, Prettier, the production build, the accessibility suite and CodeQL all passed while every `sm:`/`md:`/`lg:`/`xl:` utility was being deleted from the emitted CSS.

It shipped to production and survived both the Tailwind v3→v4 migration and the Astro 7 upgrade (#133) unnoticed, because nothing in CI ever inspects the CSS that actually gets served. The failure is invisible to every existing check: the build succeeds, the CSS parses, the classes are still in the HTML — they just have no rules behind them.

## What this adds

`scripts/verify-responsive-css.js`, run after `bun run build` in the `build-and-lint` job. It scans `dist/client/_astro/**/*.css` and fails if the built CSS has lost its breakpoints:

- at least 3 distinct breakpoint media queries
- at least 10 responsive utility selectors (`.sm\:`, `.md\:`, `.lg\:`, …)

It accepts **both** the range syntax Tailwind v4 emits (`@media (width>=64rem)`) and the legacy `min-width` form a minifier may lower it to — either is a valid way to ship breakpoints. An empty result is not.

On failure it names the likely cause, so the next person doesn't have to rediscover it:

```
✗ Responsive CSS missing from the build (7 CSS files checked)

  · expected at least 3 distinct breakpoint media queries, found 0
  · expected at least 10 responsive utility selectors, found 0

  The most likely cause is a CSS minifier discarding `@media (width>=…)`
  blocks it cannot parse. See the CSS option passed to astro-compress in
  astro.config.ts — csso does not support range syntax; lightningcss does.
```

## Verification

Run against three real builds:

| Build | Result |
|---|---|
| lightningcss (post-#135) | **pass** — 10 breakpoints, 740 responsive selectors |
| csso (pre-#135) | **fail** — 0 breakpoints, 0 responsive selectors |
| no `dist/` present | **fail** — clear "run `bun run build` first" message |

The middle row is the important one: this check would have caught the original bug.

No new dependencies — plain Node, no browser, runs in well under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)